### PR TITLE
外部ライブラリのバージョンを埋め込む

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,8 +5,8 @@
 // @description コンテスト中にAtCoderのパフォーマンスを予測します
 // @author      keymoon
 // @license     MIT
-// @require     https://greasyfork.org/scripts/386715-atcoder-sidemenu/code/atcoder-sidemenu.js
-// @require     https://greasyfork.org/scripts/386712-atcoder-userscript-libs/code/atcoder-userscript-libs.js
+// @require     https://greasyfork.org/scripts/386715-atcoder-sidemenu/code/atcoder-sidemenu.js?version=712893
+// @require     https://greasyfork.org/scripts/386712-atcoder-userscript-libs/code/atcoder-userscript-libs.js?version=712892
 // @supportURL  https://github.com/key-moon/ac-predictor.user.js/issues
 // @match       https://atcoder.jp/*
 // @exclude     https://atcoder.jp/*/json


### PR DESCRIPTION
依存するライブラリ側を更新することで、ユーザが気づけないままに悪意のあるコードを注入できるようになってしまっています。これは依存ライブラリのバージョンを固定することでかなり緩和できるので、そのようにします。