### PR TITLE
Feature/next-ac

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -466,19 +466,12 @@
       }
     },
     "atcoder-userscript-libs": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/atcoder-userscript-libs/-/atcoder-userscript-libs-0.1.3.tgz",
-      "integrity": "sha512-G504w47zV0wDtlRlTf/rrPEPRo2fZUVt5eEYp8Cg1J1fg+4QxsRXwObpxHmHY7fILdEgY5N24JK2vlCuTMOfDg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/atcoder-userscript-libs/-/atcoder-userscript-libs-0.1.4.tgz",
+      "integrity": "sha512-WXH8683/qm+4fkx676C5Obdf3PcpnTWwneheJS3fVyHTFPtwfFO7lZHELgtu6xkXCpO1VCgZf4WIFhdzPGmIPw==",
       "requires": {
         "jquery": "^3.4.0",
         "moment": "^2.24.0"
-      },
-      "dependencies": {
-        "jquery": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-          "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
-        }
       }
     },
     "atob": {
@@ -2064,8 +2057,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2086,14 +2078,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2108,20 +2098,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2238,8 +2225,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2251,7 +2237,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2266,7 +2251,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2274,14 +2258,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2300,7 +2282,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2381,8 +2362,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2394,7 +2374,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2480,8 +2459,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2517,7 +2495,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2537,7 +2514,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2582,14 +2558,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ac-predictor",
-  "version": "1.0.0",
+  "version": "1.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "ac-predictor/main.js",
   "dependencies": {
     "atcoder-sidemenu": "^0.1.3",
-    "atcoder-userscript-libs": "^0.1.3",
+    "atcoder-userscript-libs": "^0.1.4",
     "jquery": "^3.4.1",
     "moment": "^2.24.0"
   },

--- a/src/elements/predictor/dom.html
+++ b/src/elements/predictor/dom.html
@@ -21,7 +21,7 @@
 </div>
 <div class="row">
     <div class="input-group col-xs-10">
-        <select class="form-control">
+        <select class="form-control" id="predictor-nextac-select">
             <option>A問題</option>
             <option>B問題</option>
             <option>C問題</option>
@@ -30,7 +30,7 @@
             <option>F問題</option>
         </select>            
         <div class="input-group-btn">
-            <button class="btn btn-default" id="predictor-nextac">をACした場合の順位</button>
+            <button class="btn btn-default" id="predictor-nextac-button">をACした場合の順位</button>
         </div>
     </div>
 </div>

--- a/src/elements/predictor/dom.html
+++ b/src/elements/predictor/dom.html
@@ -17,9 +17,23 @@
     </div>
 </div>
 <div class="row">
-    <div class="btn-group">
         <button class="btn btn-default" id="predictor-current">現在の順位</button>
-        <button type="button" class="btn btn-primary" id="predictor-reload" data-loading-text="更新中…">更新</button>
-        <!--<button class="btn btn-default" id="predictor-solved" disabled>現問題AC後</button>-->
+</div>
+<div class="row">
+    <div class="input-group col-xs-10">
+        <select class="form-control">
+            <option>A問題</option>
+            <option>B問題</option>
+            <option>C問題</option>
+            <option>D問題</option>
+            <option>E問題</option>
+            <option>F問題</option>
+        </select>            
+        <div class="input-group-btn">
+            <button class="btn btn-default" id="predictor-nextac">をACした場合の順位</button>
+        </div>
     </div>
+</div>
+<div class="row">
+    <button type="button" class="btn btn-primary" id="predictor-reload" data-loading-text="更新中…">更新</button>
 </div>

--- a/src/elements/predictor/dom.html
+++ b/src/elements/predictor/dom.html
@@ -21,14 +21,7 @@
 </div>
 <div class="row">
     <div class="input-group col-xs-10">
-        <select class="form-control" id="predictor-nextac-select">
-            <option>A問題</option>
-            <option>B問題</option>
-            <option>C問題</option>
-            <option>D問題</option>
-            <option>E問題</option>
-            <option>F問題</option>
-        </select>            
+        <select class="form-control" id="predictor-nextac-select"></select>            
         <div class="input-group-btn">
             <button class="btn btn-default" id="predictor-nextac-button">をACした場合の順位</button>
         </div>

--- a/src/elements/predictor/model/PredictorModel.js
+++ b/src/elements/predictor/model/PredictorModel.js
@@ -39,7 +39,7 @@ export class PredictorModel {
     }
 
     /**
-     * @param {Task} tasks
+     * @param {Task[]} tasks
      */
     updateTasks(tasks) {
         this.tasks = tasks;

--- a/src/elements/predictor/model/PredictorModel.js
+++ b/src/elements/predictor/model/PredictorModel.js
@@ -8,6 +8,7 @@ export class PredictorModel {
         this.history = model.history;
         this.updateInformation(model.information);
         this.updateData(model.rankValue, model.perfValue, model.rateValue);
+        this.updateTasks(model.tasks);
     }
 
     /**
@@ -33,5 +34,9 @@ export class PredictorModel {
         this.rankValue = rankValue;
         this.perfValue = perfValue;
         this.rateValue = rateValue;
+    }
+
+    updateTasks(tasks) {
+        this.tasks = tasks;
     }
 }

--- a/src/elements/predictor/model/PredictorModel.js
+++ b/src/elements/predictor/model/PredictorModel.js
@@ -1,3 +1,5 @@
+import { Task } from "../../../libs/contest/task";
+
 export class PredictorModel {
     /**
      * @param {PredictorModel} [model]
@@ -36,6 +38,9 @@ export class PredictorModel {
         this.rateValue = rateValue;
     }
 
+    /**
+     * @param {Task} tasks
+     */
     updateTasks(tasks) {
         this.tasks = tasks;
     }

--- a/src/elements/predictor/script.js
+++ b/src/elements/predictor/script.js
@@ -131,8 +131,8 @@ async function afterAppend() {
             }
 
             const nextPoint = model.tasks.filter(x => x.assignment === nextTaskAssignment)[0].point;
-            const myTotalScore = contest.templateResults[userScreenName].TotalScore;
-            const myPenalty = contest.templateResults[userScreenName].Penalty;
+            const myTotalScore = results.getUserResult(userScreenName).TotalScore;
+            const myPenalty = results.getUserResult(userScreenName).Penalty;
             const contestPenalty = contestInformation.Penalty * 1000000;
             const nextElapsed = moment().diff(moment(startTime)) * 1000000;
             const nextRank = getInsertedRatedRank(myTotalScore + nextPoint, nextElapsed + contestPenalty * myPenalty);

--- a/src/elements/predictor/script.js
+++ b/src/elements/predictor/script.js
@@ -4,6 +4,7 @@ import moment from "moment";
 import { SideMenuElement } from "atcoder-sidemenu";
 import { PredictorDB } from "../../libs/database/predictorDB";
 import { Contest } from "../../libs/contest/contest";
+import { Task } from "../../libs/contest/task";
 import { OnDemandResults } from "../../libs/contest/results/standingsResults";
 import { FixedResults } from "../../libs/contest/results/fIxedResults";
 import { Result } from "../../libs/contest/results/result";
@@ -218,7 +219,7 @@ async function afterAppend() {
         }
 
         try {
-            const tasks = await getContestTaskData(contestScreenName);
+            const tasks = await getContestTasks(contestScreenName);
             model.updateTasks(tasks);
             for (const task of tasks) {
                 $("#predictor-nextac-select").append(`<option value="${task.assignment}">${task.assignment}問題</option>`)
@@ -227,16 +228,17 @@ async function afterAppend() {
             throw new Error("配点の取得に失敗しました。");
         }
 
-        async function getContestTaskData(contestScreenName) {
-            const tasks = standings.TaskInfo;
-            let points = [];
-            for (const task of tasks) {
-                points.push({
-                    assignment: task.Assignment,
-                    point: (await getTaskPoint(task.TaskScreenName))
-                });
+        async function getContestTasks(contestScreenName) {
+            const standingsTaskInfo = standings.TaskInfo;
+            let tasks = [];
+            for (const taskData of standingsTaskInfo) {
+                tasks.push(new Task(
+                    taskData.Assignment,
+                    (await getTaskPoint(taskData.TaskScreenName)),
+                    taskData.TaskScreenName
+                ))
             }
-            return points;
+            return tasks;
 
             async function getTaskPoint(taskScreenName) {
                 const taskPageDom = await $.ajax(`https://atcoder.jp/contests/${contestScreenName}/tasks/${taskScreenName}`).then(x => new DOMParser().parseFromString(x, "text/html"));

--- a/src/elements/predictor/script.js
+++ b/src/elements/predictor/script.js
@@ -46,6 +46,7 @@ const predictorElements = [
     "predictor-current",
     "predictor-nextac-select",
     "predictor-nextac-button",
+    "predictor-nextac-warning",
     "predictor-reload",
     "predictor-tweet"
 ];
@@ -111,8 +112,22 @@ async function afterAppend() {
             updateView();
         });
         $("#predictor-nextac-button").click(async function() {
-            const nextTaskName = $("#predictor-nextac-select option:selected").val();
-            const nextPoint = model.tasks.filter(x => x.assignment === nextTaskName)[0].point;
+            $("#predictor-nextac-warning").alert("close");
+
+            const myTaskResults = contest.standings.StandingsData.filter(x => x.UserScreenName === userScreenName)[0].TaskResults;
+            const myACTaskScreenNames = Object.keys(myTaskResults).filter(taskScreenName => myTaskResults[taskScreenName].Status === 1);
+            const myACTaskAssignments = myACTaskScreenNames.map(taskScreenName => {
+                return model.tasks.filter(task => task.taskScreenName === taskScreenName)[0].assignment;
+            });
+
+            const nextTaskAssignment = $("#predictor-nextac-select option:selected").val();
+            if (myACTaskAssignments.includes(nextTaskAssignment)) {
+                const alertDom = `<div class="alert alert-warning col-xs-7" role="alert" id="predictor-nextac-warning" style="float: right; padding: 5.5px 12px; margin-bottom: 0px;"><button type="button" class="close" data-dismiss="alert" aria-label="閉じる"><span aria-hidden="true">×</span></button><span>この問題はAC済です</span></div>`;
+                $("#predictor-current").after(alertDom);
+                return;
+            }
+
+            const nextPoint = model.tasks.filter(x => x.assignment === nextTaskAssignment)[0].point;
             const myTotalScore = contest.templateResults[userScreenName].TotalScore;
             const myPenalty = contest.templateResults[userScreenName].Penalty;
             // This is bugged, waiting for the update of "atcoder-userscript-libs".

--- a/src/elements/predictor/script.js
+++ b/src/elements/predictor/script.js
@@ -135,7 +135,7 @@ async function afterAppend() {
             const myPenalty = results.getUserResult(userScreenName).Penalty;
             const contestPenalty = contestInformation.Penalty * 1000000;
             const nextElapsed = moment().diff(moment(startTime)) * 1000000;
-            const nextRank = getInsertedRatedRank(myTotalScore + nextPoint, nextElapsed + contestPenalty * myPenalty);
+            const nextRank = results.getInsertedRatedRank(myTotalScore + nextPoint, nextElapsed + contestPenalty * myPenalty);
             model = new CalcFromRankModel(model);
             model.updateData(
                 nextRank,
@@ -143,18 +143,6 @@ async function afterAppend() {
                 model.rateValue
             );
             updateView();
-
-            function getInsertedRatedRank(totalScore, elapsed) {
-                let ratedRank = 1;
-                const resultsDic = results instanceof FixedResults ? results.resultsDic : results.TemplateResults;
-                const resultsArray = Object.values(resultsDic);
-                for (const result of resultsArray) {
-                    if ((result.TotalScore === totalScore && result.Elapsed >= elapsed) || (result.TotalScore < totalScore)) {
-                        return ratedRank;
-                    }
-                    if (result.IsRated) ratedRank++;
-                }
-            }
         });
         $("#predictor-input-rank").keyup(function() {
             const inputString = $("#predictor-input-rank").val();

--- a/src/elements/predictor/script.js
+++ b/src/elements/predictor/script.js
@@ -114,7 +114,10 @@ async function afterAppend() {
         $("#predictor-nextac-button").click(async function() {
             $("#predictor-nextac-warning").alert("close");
 
-            const myTaskResults = contest.standings.StandingsData.filter(x => x.UserScreenName === userScreenName)[0].TaskResults;
+            const myData = contest.standings.StandingsData.filter(x => x.UserScreenName === userScreenName)[0];
+            if (!myData) return;
+
+            const myTaskResults = myData.TaskResults;
             const myACTaskScreenNames = Object.keys(myTaskResults).filter(taskScreenName => myTaskResults[taskScreenName].Status === 1);
             const myACTaskAssignments = myACTaskScreenNames.map(taskScreenName => {
                 return model.tasks.filter(task => task.taskScreenName === taskScreenName)[0].assignment;

--- a/src/elements/predictor/script.js
+++ b/src/elements/predictor/script.js
@@ -120,7 +120,7 @@ async function afterAppend() {
             const myTaskResults = myData.TaskResults;
             const myACTaskScreenNames = Object.keys(myTaskResults).filter(taskScreenName => myTaskResults[taskScreenName].Status === 1);
             const myACTaskAssignments = myACTaskScreenNames.map(taskScreenName => {
-                return model.tasks.filter(task => task.taskScreenName === taskScreenName)[0].assignment;
+                return model.tasks.find(task => task.taskScreenName === taskScreenName).assignment;
             });
 
             const nextTaskAssignment = $("#predictor-nextac-select option:selected").val();

--- a/src/elements/predictor/script.js
+++ b/src/elements/predictor/script.js
@@ -168,7 +168,7 @@ async function afterAppend() {
             const tasks = await getContestTaskData(contestScreenName);
             model.tasks = tasks;
             for (const task of tasks) {
-                $("#predictor-nextac-select").append(`<option>${task.assignment}問題</option>`)
+                $("#predictor-nextac-select").append(`<option value="${task.assignment}">${task.assignment}問題</option>`)
             }
         } catch (e) {
             throw new Error("配点の取得に失敗しました。");

--- a/src/elements/predictor/script.js
+++ b/src/elements/predictor/script.js
@@ -109,6 +109,59 @@ async function afterAppend() {
             );
             updateView();
         });
+        $("#predictor-nextac-button").click(async function() {
+            const nextTaskName = $("#predictor-nextac-select option:selected").val();
+            const nextPoint = model.tasks.filter(x => x.assignment === nextTaskName)[0].point;
+            const myTotalScore = contest.templateResults[userScreenName].TotalScore;
+            const myPenalty = contest.templateResults[userScreenName].Penalty;
+            // This is bugged, waiting for the update of "atcoder-userscript-libs".
+            // const contestPenalty = contestInformation.Penalty;
+            const contestPenalty = await fetchContestPenalty(contestScreenName);
+            const nextElapsed = moment().diff(moment(startTime)) * 1000000;
+            const nextRank = getInsertedRatedRank(myTotalScore + nextPoint, nextElapsed + contestPenalty * myPenalty);
+            model = new CalcFromRankModel(model);
+            model.updateData(
+                nextRank,
+                model.perfValue,
+                model.rateValue
+            );
+            updateView();
+
+            function getInsertedRatedRank(totalScore, elapsed) {
+                let ratedRank = 1;
+                const resultsDic = results instanceof FixedResults ? results.resultsDic : results.templateResults;
+                const resultsArray = Object.values(resultsDic);
+                for (const result of resultsArray) {
+                    if ((result.TotalScore === totalScore && result.Elapsed >= elapsed) || (result.TotalScore < totalScore)) {
+                        return ratedRank;
+                    }
+                    if (result.IsRated) ratedRank++;
+                }
+            }
+            async function fetchContestPenalty(contestScreenName) {
+                return new Promise(async (resolve) => {
+                    const topPageDom = await $.ajax(`https://atcoder.jp/contests/${contestScreenName}`).then(x => new DOMParser().parseFromString(x, "text/html"));
+                    const dataParagraph = topPageDom.getElementsByClassName("small")[0];
+                    const data = Array.from(dataParagraph.children).map(x => x.innerText.split(':')[1].trim());
+                    resolve(parseDurationString(data[2]));
+    
+                    function parseDurationString(s) {
+                        if (s === "None" || s === "なし") return 0;
+                        if (!/(\d+[^\d]+)/.test(s)) return NaN;
+                        const dic = {ヶ月: "month", 日: "day", 時間: "hour", 分: "minute", 秒: "second"};
+                        let res = {};
+                        s.match(/(\d+[^\d]+)/g).forEach(x => {
+                            const trimmed = x.trim(' ','s');
+                            const num = trimmed.match(/\d+/)[0];
+                            const unit = trimmed.match(/[^\d]+/)[0];
+                            const convertedUnit = dic[unit]||unit;
+                            res[convertedUnit] = num;
+                        });
+                        return moment.duration(res).asMilliseconds();
+                    }
+                });
+            }
+        });
         $("#predictor-input-rank").keyup(function() {
             const inputString = $("#predictor-input-rank").val();
             if (!isFinite(inputString)) return;
@@ -166,7 +219,7 @@ async function afterAppend() {
 
         try {
             const tasks = await getContestTaskData(contestScreenName);
-            model.tasks = tasks;
+            model.updateTasks(tasks);
             for (const task of tasks) {
                 $("#predictor-nextac-select").append(`<option value="${task.assignment}">${task.assignment}問題</option>`)
             }

--- a/src/elements/predictor/script.js
+++ b/src/elements/predictor/script.js
@@ -101,7 +101,7 @@ async function afterAppend() {
             updateView();
         });
         $("#predictor-current").click(function() {
-            const myResult = contest.templateResults[userScreenName];
+            const myResult = contest.templateResults.get(userScreenName);
             if (!myResult) return;
             model = new CalcFromRankModel(model);
             model.updateData(

--- a/src/elements/predictor/script.js
+++ b/src/elements/predictor/script.js
@@ -134,8 +134,8 @@ async function afterAppend() {
             const myTotalScore = contest.templateResults[userScreenName].TotalScore;
             const myPenalty = contest.templateResults[userScreenName].Penalty;
             // This is bugged, waiting for the update of "atcoder-userscript-libs".
-            // const contestPenalty = contestInformation.Penalty;
-            const contestPenalty = await fetchContestPenalty(contestScreenName);
+            // const contestPenalty = contestInformation.Penalty * 1000000;
+            const contestPenalty = await fetchContestPenalty(contestScreenName) * 1000000;
             const nextElapsed = moment().diff(moment(startTime)) * 1000000;
             const nextRank = getInsertedRatedRank(myTotalScore + nextPoint, nextElapsed + contestPenalty * myPenalty);
             model = new CalcFromRankModel(model);

--- a/src/elements/predictor/script.js
+++ b/src/elements/predictor/script.js
@@ -148,7 +148,7 @@ async function afterAppend() {
 
             function getInsertedRatedRank(totalScore, elapsed) {
                 let ratedRank = 1;
-                const resultsDic = results instanceof FixedResults ? results.resultsDic : results.templateResults;
+                const resultsDic = results instanceof FixedResults ? results.resultsDic : results.TemplateResults;
                 const resultsArray = Object.values(resultsDic);
                 for (const result of resultsArray) {
                     if ((result.TotalScore === totalScore && result.Elapsed >= elapsed) || (result.TotalScore < totalScore)) {

--- a/src/elements/predictor/script.js
+++ b/src/elements/predictor/script.js
@@ -168,7 +168,7 @@ async function afterAppend() {
             const tasks = await getContestTaskData(contestScreenName);
             model.tasks = tasks;
             for (const task of tasks) {
-                $("#predictor-nextac-select").append(`<option>${task[0]}問題</option>`)
+                $("#predictor-nextac-select").append(`<option>${task.assignment}問題</option>`)
             }
         } catch (e) {
             throw new Error("配点の取得に失敗しました。");
@@ -178,10 +178,10 @@ async function afterAppend() {
             const tasks = standings.TaskInfo;
             let points = [];
             for (const task of tasks) {
-                points.push([
-                    task.Assignment,
-                    (await getTaskPoint(task.TaskScreenName))
-                ]);
+                points.push({
+                    assignment: task.Assignment,
+                    point: (await getTaskPoint(task.TaskScreenName))
+                });
             }
             return points;
 

--- a/src/elements/predictor/script.js
+++ b/src/elements/predictor/script.js
@@ -324,7 +324,8 @@ async function afterAppend() {
                         result && result.IsRated
                             ? (lastPerformance = result.Performance)
                             : lastPerformance,
-                        result ? result.InnerPerformance : 0
+                        result ? result.InnerPerformance : 0,
+                        data.TotalResult.Score
                     );
                 })
             );

--- a/src/elements/predictor/script.js
+++ b/src/elements/predictor/script.js
@@ -356,7 +356,9 @@ async function afterAppend() {
                             ? (lastPerformance = result.Performance)
                             : lastPerformance,
                         result ? result.InnerPerformance : 0,
-                        data.TotalResult.Score
+                        data.TotalResult.Score,
+                        data.TotalResult.Elapsed,
+                        data.TotalResult.Penalty
                     );
                 })
             );

--- a/src/elements/predictor/script.js
+++ b/src/elements/predictor/script.js
@@ -133,9 +133,7 @@ async function afterAppend() {
             const nextPoint = model.tasks.filter(x => x.assignment === nextTaskAssignment)[0].point;
             const myTotalScore = contest.templateResults[userScreenName].TotalScore;
             const myPenalty = contest.templateResults[userScreenName].Penalty;
-            // This is bugged, waiting for the update of "atcoder-userscript-libs".
-            // const contestPenalty = contestInformation.Penalty * 1000000;
-            const contestPenalty = await fetchContestPenalty(contestScreenName) * 1000000;
+            const contestPenalty = contestInformation.Penalty * 1000000;
             const nextElapsed = moment().diff(moment(startTime)) * 1000000;
             const nextRank = getInsertedRatedRank(myTotalScore + nextPoint, nextElapsed + contestPenalty * myPenalty);
             model = new CalcFromRankModel(model);
@@ -156,29 +154,6 @@ async function afterAppend() {
                     }
                     if (result.IsRated) ratedRank++;
                 }
-            }
-            async function fetchContestPenalty(contestScreenName) {
-                return new Promise(async (resolve) => {
-                    const topPageDom = await $.ajax(`https://atcoder.jp/contests/${contestScreenName}`).then(x => new DOMParser().parseFromString(x, "text/html"));
-                    const dataParagraph = topPageDom.getElementsByClassName("small")[0];
-                    const data = Array.from(dataParagraph.children).map(x => x.innerText.split(':')[1].trim());
-                    resolve(parseDurationString(data[2]));
-    
-                    function parseDurationString(s) {
-                        if (s === "None" || s === "なし") return 0;
-                        if (!/(\d+[^\d]+)/.test(s)) return NaN;
-                        const dic = {ヶ月: "month", 日: "day", 時間: "hour", 分: "minute", 秒: "second"};
-                        let res = {};
-                        s.match(/(\d+[^\d]+)/g).forEach(x => {
-                            const trimmed = x.trim(' ','s');
-                            const num = trimmed.match(/\d+/)[0];
-                            const unit = trimmed.match(/[^\d]+/)[0];
-                            const convertedUnit = dic[unit]||unit;
-                            res[convertedUnit] = num;
-                        });
-                        return moment.duration(res).asMilliseconds();
-                    }
-                });
             }
         });
         $("#predictor-input-rank").keyup(function() {

--- a/src/elements/predictor/script.js
+++ b/src/elements/predictor/script.js
@@ -137,7 +137,8 @@ async function afterAppend() {
             const nextPenalty = currentTaskResults[nextTaskScreenName] ? currentTaskResults[nextTaskScreenName].Failure : 0;
             const contestPenalty = contestInformation.Penalty * 1000000;
             const nextElapsed = moment().diff(moment(startTime)) * 1000000;
-            const nextRank = results.getInsertedRatedRank(currentTotalScore + nextPoint, nextElapsed + contestPenalty * (currentPenalty * nextPenalty));
+            const penaltyTime = contestPenalty * (currentPenalty + nextPenalty)
+            const nextRank = results.getInsertedRatedRank(currentTotalScore + nextPoint, nextElapsed + penaltyTime);
             model = new CalcFromRankModel(model);
             model.updateData(
                 nextRank,

--- a/src/elements/predictor/script.js
+++ b/src/elements/predictor/script.js
@@ -188,7 +188,7 @@ async function afterAppend() {
             async function getTaskPoint(taskScreenName) {
                 const taskPageDom = await $.ajax(`https://atcoder.jp/contests/${contestScreenName}/tasks/${taskScreenName}`).then(x => new DOMParser().parseFromString(x, "text/html"));
                 const point = parseInt($(taskPageDom).find("#task-statement").find("var").eq(0).text());
-                if (!isNaN(point)) return point;
+                if (!isNaN(point)) return point * 100;
                 else throw new Error();
             }
         }

--- a/src/elements/predictor/script.js
+++ b/src/elements/predictor/script.js
@@ -167,6 +167,9 @@ async function afterAppend() {
         try {
             const tasks = await getContestTaskData(contestScreenName);
             model.tasks = tasks;
+            for (const task of tasks) {
+                $("#predictor-nextac-select").append(`<option>${task[0]}問題</option>`)
+            }
         } catch (e) {
             throw new Error("配点の取得に失敗しました。");
         }

--- a/src/libs/contest/contest.js
+++ b/src/libs/contest/contest.js
@@ -76,7 +76,9 @@ export class Contest {
                             data.Competitions,
                             null,
                             null,
-                            data.TotalResult.Score
+                            data.TotalResult.Score,
+                            data.TotalResult.Elapsed,
+                            data.TotalResult.Penalty
                         );
                     });
                     currentRatedRank += ratedInTiedUsers;

--- a/src/libs/contest/contest.js
+++ b/src/libs/contest/contest.js
@@ -19,7 +19,7 @@ export class Contest {
         this.templateResults = analyzedData.templateResults;
         this.IsRated = analyzedData.isRated;
 
-        /** @return {{contestantAPerf: number[], templateResults: Object<string, Result>, isRated: boolean}} */
+        /** @return {{contestantAPerf: number[], templateResults: Map<string, Result>, isRated: boolean}} */
         function analyzeStandingsData(
             fixed,
             standingsData,
@@ -41,10 +41,10 @@ export class Contest {
             }
             return analyzedData;
 
-            /** @return {{contestantAPerf: number[], templateResults: Object.<string, Result>}}*/
+            /** @return {{contestantAPerf: number[], templateResults: Map<string, Result>}}*/
             function analyze(isUserRated) {
                 let contestantAPerf = [];
-                let templateResults = {};
+                let templateResults = new Map();
 
                 let currentRatedRank = 1;
 
@@ -65,7 +65,7 @@ export class Contest {
                         currentRatedRank +
                         Math.max(0, ratedInTiedUsers - 1) / 2;
                     tiedUsers.forEach(data => {
-                        templateResults[data.UserScreenName] = new Result(
+                        templateResults.set(data.UserScreenName, new Result(
                             isUserRated(data),
                             data.TotalResult.Count !== 0,
                             data.UserScreenName,
@@ -79,7 +79,7 @@ export class Contest {
                             data.TotalResult.Score,
                             data.TotalResult.Elapsed,
                             data.TotalResult.Penalty
-                        );
+                        ));
                     });
                     currentRatedRank += ratedInTiedUsers;
                     tiedUsers.length = 0;

--- a/src/libs/contest/contest.js
+++ b/src/libs/contest/contest.js
@@ -75,7 +75,8 @@ export class Contest {
                             null,
                             data.Competitions,
                             null,
-                            null
+                            null,
+                            data.TotalResult.Score
                         );
                     });
                     currentRatedRank += ratedInTiedUsers;

--- a/src/libs/contest/results/fIxedResults.js
+++ b/src/libs/contest/results/fIxedResults.js
@@ -6,9 +6,9 @@ export class FixedResults extends Results {
      */
     constructor(results) {
         super();
-        this.resultsDic = {};
+        this.resultsDic = new Map();
         results.forEach(result => {
-            this.resultsDic[result.UserScreenName] = result;
+            this.resultsDic.set(result.UserScreenName, result);
         });
     }
     /**
@@ -16,7 +16,7 @@ export class FixedResults extends Results {
      * @return {Result}
      */
     getUserResult(userScreenName) {
-        return this.resultsDic[userScreenName] || null;
+        return this.resultsDic.get(userScreenName) || null;
     }
     /**
      * @param {number} totalScore
@@ -25,8 +25,8 @@ export class FixedResults extends Results {
      */
     getInsertedRatedRank(totalScore, elapsed) {
         let ratedRank = 1;
-        const resultsArray = Object.values(this.resultsDic);
-        for (const result of resultsArray) {
+        const resultsIterator = this.resultsDic.values();
+        for (const result of resultsIterator) {
             if ((result.TotalScore === totalScore && result.Elapsed >= elapsed) || (result.TotalScore < totalScore)) {
                 return ratedRank;
             }

--- a/src/libs/contest/results/fIxedResults.js
+++ b/src/libs/contest/results/fIxedResults.js
@@ -18,4 +18,19 @@ export class FixedResults extends Results {
     getUserResult(userScreenName) {
         return this.resultsDic[userScreenName] || null;
     }
+    /**
+     * @param {number} totalScore
+     * @param {number} elapsed
+     * @return {number}
+     */
+    getInsertedRatedRank(totalScore, elapsed) {
+        let ratedRank = 1;
+        const resultsArray = Object.values(this.resultsDic);
+        for (const result of resultsArray) {
+            if ((result.TotalScore === totalScore && result.Elapsed >= elapsed) || (result.TotalScore < totalScore)) {
+                return ratedRank;
+            }
+            if (result.IsRated) ratedRank++;
+        }
+    }
 }

--- a/src/libs/contest/results/result.js
+++ b/src/libs/contest/results/result.js
@@ -10,6 +10,7 @@ export class Result {
      * @param {number} innerPerformance
      * @param {number} oldRating
      * @param {number} newRating
+     * @param {number} totalScore
      */
     constructor(
         isRated,
@@ -21,7 +22,8 @@ export class Result {
         newRating,
         competitions,
         performance,
-        innerPerformance
+        innerPerformance,
+        totalScore
     ) {
         this.IsRated = isRated;
         this.IsSubmitted = isSubmitted;
@@ -33,5 +35,6 @@ export class Result {
         this.Competitions = competitions;
         this.Performance = performance;
         this.InnerPerformance = innerPerformance;
+        this.TotalScore = totalScore;
     }
 }

--- a/src/libs/contest/results/result.js
+++ b/src/libs/contest/results/result.js
@@ -11,6 +11,8 @@ export class Result {
      * @param {number} oldRating
      * @param {number} newRating
      * @param {number} totalScore
+     * @param {number} elapsed
+     * @param {number} penalty
      */
     constructor(
         isRated,
@@ -23,7 +25,9 @@ export class Result {
         competitions,
         performance,
         innerPerformance,
-        totalScore
+        totalScore,
+        elapsed,
+        penalty
     ) {
         this.IsRated = isRated;
         this.IsSubmitted = isSubmitted;
@@ -36,5 +40,7 @@ export class Result {
         this.Performance = performance;
         this.InnerPerformance = innerPerformance;
         this.TotalScore = totalScore;
+        this.Elapsed = elapsed;
+        this.Penalty = penalty;
     }
 }

--- a/src/libs/contest/results/results.js
+++ b/src/libs/contest/results/results.js
@@ -5,4 +5,10 @@ export class Results {
      * @return {Result}
      */
     getUserResult(userScreenName) {}
+    /**
+     * @param {number} totalScore
+     * @param {number} elapsed
+     * @return {number}
+     */
+    getInsertedRatedRank(totalScore, elapsed) {}
 }

--- a/src/libs/contest/results/standingsResults.js
+++ b/src/libs/contest/results/standingsResults.js
@@ -48,13 +48,11 @@ export class OnDemandResults extends Results {
      * @return {number}
      */
     getInsertedRatedRank(totalScore, elapsed) {
-        let ratedRank = 1;
         const resultsArray = Object.values(this.TemplateResults);
         for (const result of resultsArray) {
             if ((result.TotalScore === totalScore && result.Elapsed >= elapsed) || (result.TotalScore < totalScore)) {
-                return ratedRank;
+                return result.RatedRank;
             }
-            if (result.IsRated) ratedRank++;
         }
     }
 }

--- a/src/libs/contest/results/standingsResults.js
+++ b/src/libs/contest/results/standingsResults.js
@@ -42,4 +42,19 @@ export class OnDemandResults extends Results {
         }
         return baseResults;
     }
+    /**
+     * @param {number} totalScore
+     * @param {number} elapsed
+     * @return {number}
+     */
+    getInsertedRatedRank(totalScore, elapsed) {
+        let ratedRank = 1;
+        const resultsArray = Object.values(this.TemplateResults);
+        for (const result of resultsArray) {
+            if ((result.TotalScore === totalScore && result.Elapsed >= elapsed) || (result.TotalScore < totalScore)) {
+                return ratedRank;
+            }
+            if (result.IsRated) ratedRank++;
+        }
+    }
 }

--- a/src/libs/contest/results/standingsResults.js
+++ b/src/libs/contest/results/standingsResults.js
@@ -20,7 +20,7 @@ export class OnDemandResults extends Results {
      * @return {Result}
      */
     getUserResult(userScreenName) {
-        const baseResults = this.TemplateResults[userScreenName];
+        const baseResults = this.TemplateResults.get(userScreenName);
         if (!baseResults) return null;
         if (!baseResults.Performance) {
             baseResults.InnerPerformance = this.Contest.getInnerPerf(
@@ -48,8 +48,8 @@ export class OnDemandResults extends Results {
      * @return {number}
      */
     getInsertedRatedRank(totalScore, elapsed) {
-        const resultsArray = Object.values(this.TemplateResults);
-        for (const result of resultsArray) {
+        const resultsIterator = this.TemplateResults.values();
+        for (const result of resultsIterator) {
             if ((result.TotalScore === totalScore && result.Elapsed >= elapsed) || (result.TotalScore < totalScore)) {
                 return result.RatedRank;
             }

--- a/src/libs/contest/task.js
+++ b/src/libs/contest/task.js
@@ -1,0 +1,12 @@
+export class Task {
+    /**
+     * @param {string} assignment
+     * @param {number} point
+     * @param {string} taskScreenName
+     */
+    constructor(assignment, point, taskScreenName) {
+        this.assignment = assignment;
+        this.point = point;
+        this.taskScreenName = taskScreenName;
+    }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@
 // @author      keymoon
 // @license     MIT
 // @require     https://greasyfork.org/scripts/386715-atcoder-sidemenu/code/atcoder-sidemenu.js?version=712893
-// @require     https://greasyfork.org/scripts/386712-atcoder-userscript-libs/code/atcoder-userscript-libs.js?version=712892
+// @require     https://greasyfork.org/scripts/386712-atcoder-userscript-libs/code/atcoder-userscript-libs.js?version=715082
 // @supportURL  https://github.com/key-moon/ac-predictor.user.js/issues
 // @match       https://atcoder.jp/*
 // @exclude     https://atcoder.jp/*/json


### PR DESCRIPTION
#17 を実装しました。元のIssueでは「現在開いているページの問題を正解した場合の順位」でしたが、順位表ページなどでも見れるようになりたいので、「指定した問題を正解した場合の順位」としました。

<img width="254" alt="キャプチャ" src="https://user-images.githubusercontent.com/40035906/60727541-1b562380-9f79-11e9-8374-d24a556434a7.PNG">

### 実装方針
実際に該当する問題を解いた後の(パフォーマンスを含めた)順位表を正確に取得するのは現状無理なので、現在の順位表でどこに挿入されるか(何位に相当するか)を取得することで近似しています。
### 変更箇所
新たに必要となる情報は以下の通りです。
- 全員の現在のスコア(`result.TotalScore`)、およびペナルティを含めた経過時間(`result.Elapsed`)
- 各問題の名前(`task.assignment`)、配点(`task.point`) (`task.taskScreenName`はユーザーの`TaskResults`との兼ね合いで必要です)
- ユーザーのペナルティ
- ユーザーがAC済の問題

これらの情報を追加するために、`Result`クラスを書き換え、`Task`クラスを追加しています。
### その他
`$("#predictor-nextac-button")`を押した際にそこそこ重くなります。今のところ考えている原因は2つあります。
1. `fetchContestPenalty`が重い
atcoder-userscript-libsの[#2](https://github.com/key-moon/atcoder-userscript-libs/commit/468b77e9a5cb33f781ce32bcdc7ffa39cc02a469)修正分がリリースされたら、コメントアウトされた`contestInformation.Penalty`に切り替えることでリクエストが1つ減ります。
2. `contest.standings.StandingsData.filter`が重い
現在ユーザーがAC済の問題を取得するためにstandingsでループを回しています。まともに計測していないのでこれが本当に重いかはわかりません。`Result`で`TaskResults`を持てばいい気がしますが、それはそれで前処理が重くなる気がします。

あと、ページにアクセスするたび(`initPredictor()`が呼ばれるたび)に、配点の取得のために(通常コンなら)6つのリクエストが新たに飛ぶので、サーバーに負担をかけることになると思います。途中で配点が変わったり問題が消えたりすることは(某forcesではないので)ありえないと仮定すると、一度取得したらローカルで持つようにしてもいいかもしれません。